### PR TITLE
publish.ps1 compatibility issue

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -54,6 +54,7 @@ Write-Host ""
 Write-Host "Publishing AWS Lambda function sources"
 
 Add-Type -assembly "System.IO.Compression"
+Add-Type -assembly "System.IO.Compression.filesystem"
 
 Get-ChildItem "lambda" -Filter *.js | Foreach-Object {
   $FullName = $_.FullName


### PR DESCRIPTION
Updated the publish.ps1 to include the missing assembly name for compatibility with zip file creation.