### PR TITLE
Allow for AWS longer resource names

### DIFF
--- a/cfn/1-core.json
+++ b/cfn/1-core.json
@@ -83,8 +83,8 @@
 		"AWSAmiId" : {
 			"Description"          : "Identifier of the Amazon Machine Image to use for the platforms (all machines are started using the same AMI). We use Microsoft Windows Server 2012 R2 Base 64bits.",
 			"Type"                 : "String",
-			"AllowedPattern"       : "ami-([0-9a-fA-F]{8})",
-			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxx)."
+			"AllowedPattern"       : "((ami-([0-9a-fA-F]{8}))|(ami-([0-9a-fA-F]{17})))",
+			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxxxxxxxxxxx or ami-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)."
 		},
 		"BastionInstanceType" : {
 			"Description": "Instance type to use for the Bastion Instance",
@@ -107,8 +107,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [ 
-						{ 
+					"Statement": [
+						{
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -384,7 +384,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": { 
+								"content": {
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\local-admin-password.conf"
 									] ]
@@ -442,7 +442,7 @@
 					{ "AssociatePublicIpAddress": "true", "DeviceIndex": 0, "SubnetId": { "Ref" : "PublicSubnet" }, "GroupSet": [ { "Ref": "BastionSecurityGroup" } ] }
 				],
 				"UserData": {
-					"Fn::Base64": { 
+					"Fn::Base64": {
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r Bastion ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -541,7 +541,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": { 
+								"content": {
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf",
 										"DEL c:\\cfn\\install\\local-admin-password.conf",
@@ -613,7 +613,7 @@
 					{ "DeviceName" : "/dev/sda1", "Ebs" : { "VolumeType" : "gp2" } }
 				],
 				"UserData": {
-					"Fn::Base64": { 
+					"Fn::Base64": {
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r DomainController ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -639,7 +639,7 @@
 			}
 		},
 
-		"VPCDHCPOptionsAssoc": { 
+		"VPCDHCPOptionsAssoc": {
 			"DependsOn" : ["DomainControllerWaitCondition"],
 			"Type" : "AWS::EC2::VPCDHCPOptionsAssociation",
 			"Properties" : {

--- a/cfn/1-core.json
+++ b/cfn/1-core.json
@@ -83,8 +83,8 @@
 		"AWSAmiId" : {
 			"Description"          : "Identifier of the Amazon Machine Image to use for the platforms (all machines are started using the same AMI). We use Microsoft Windows Server 2012 R2 Base 64bits.",
 			"Type"                 : "String",
-			"AllowedPattern"       : "((ami-([0-9a-fA-F]{8}))|(ami-([0-9a-fA-F]{17})))",
-			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxxxxxxxxxxx or ami-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)."
+			"AllowedPattern"       : "ami-([0-9a-fA-F]{8})",
+			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxx)."
 		},
 		"BastionInstanceType" : {
 			"Description": "Instance type to use for the Bastion Instance",
@@ -107,8 +107,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [
-						{
+					"Statement": [ 
+						{ 
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -384,7 +384,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": {
+								"content": { 
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\local-admin-password.conf"
 									] ]
@@ -442,7 +442,7 @@
 					{ "AssociatePublicIpAddress": "true", "DeviceIndex": 0, "SubnetId": { "Ref" : "PublicSubnet" }, "GroupSet": [ { "Ref": "BastionSecurityGroup" } ] }
 				],
 				"UserData": {
-					"Fn::Base64": {
+					"Fn::Base64": { 
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r Bastion ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -541,7 +541,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": {
+								"content": { 
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf",
 										"DEL c:\\cfn\\install\\local-admin-password.conf",
@@ -613,7 +613,7 @@
 					{ "DeviceName" : "/dev/sda1", "Ebs" : { "VolumeType" : "gp2" } }
 				],
 				"UserData": {
-					"Fn::Base64": {
+					"Fn::Base64": { 
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r DomainController ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -639,7 +639,7 @@
 			}
 		},
 
-		"VPCDHCPOptionsAssoc": {
+		"VPCDHCPOptionsAssoc": { 
 			"DependsOn" : ["DomainControllerWaitCondition"],
 			"Type" : "AWS::EC2::VPCDHCPOptionsAssociation",
 			"Properties" : {

--- a/cfn/2-cluster.json
+++ b/cfn/2-cluster.json
@@ -10,19 +10,19 @@
 		"SnapshotID" : {
 			"Description"          : "Snapshot Id of the HPC Installation data",
 			"Type"                 : "String",
-			"AllowedPattern"       : "snap-([0-9a-fA-F]{8})",
+			"AllowedPattern"       : "((snap-([0-9a-fA-F]{8}))|(snap-([0-9a-fA-F]{17})))",
 			"ConstraintDescription": "must be a valid snapshot ID."
 		},
 		"ClusterSubnetID" : {
 			"Description"          : "Subnet Id of the HPC cluster",
 			"Type"                 : "String",
-			"AllowedPattern"       : "subnet-([0-9a-fA-F]{8})",
+			"AllowedPattern"       : "((subnet-([0-9a-fA-F]{8}))|(subnet-([0-9a-fA-F]{17})))",
 			"ConstraintDescription": "must be a valid subnet ID."
 		},
 		"ClusterSecurityGroupID" : {
 			"Description"          : "Security Group Id of the HPC cluster",
 			"Type"                 : "String",
-			"AllowedPattern"       : "sg-([0-9a-fA-F]{8})",
+			"AllowedPattern"       : "((sg-([0-9a-fA-F]{8}))|(sg-([0-9a-fA-F]{17})))",
 			"ConstraintDescription": "must be a valid security group ID."
 		},
 		"DomainDNSName" : {
@@ -58,8 +58,8 @@
 		"AWSAmiId" : {
 			"Description"          : "Identifier of the Amazon Machine Image to use for the platforms (all machines are started using the same AMI). We use Microsoft Windows Server 2012 R2 Base 64bits.",
 			"Type"                 : "String",
-			"AllowedPattern"       : "ami-([0-9a-fA-F]{8})",
-			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxx)."
+			"AllowedPattern"       : "((ami-([0-9a-fA-F]{8}))|(ami-([0-9a-fA-F]{17})))",
+			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxxxxxxxxxxx or ami-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)."
 		},
 		"HeadNodeInstanceType" : {
 			"Description": "Instance type to use for the Head Node Instance",
@@ -117,8 +117,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [ 
-						{ 
+					"Statement": [
+						{
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -162,8 +162,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [ 
-						{ 
+					"Statement": [
+						{
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -311,7 +311,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": { 
+								"content": {
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf"
 									] ]
@@ -383,7 +383,7 @@
 					{ "DeviceName" : "xvdf", "Ebs" : { "SnapshotId": { "Ref": "SnapshotID" }, "VolumeSize": 100, "VolumeType" : "gp2", "DeleteOnTermination": true } }
 				],
 				"UserData": {
-					"Fn::Base64": { 
+					"Fn::Base64": {
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r HeadNode ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -469,7 +469,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": { 
+								"content": {
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf"
 									] ]
@@ -532,7 +532,7 @@
 					{ "DeviceName" : "xvdf", "Ebs" : { "SnapshotId": { "Ref": "SnapshotID" }, "VolumeSize": 100, "VolumeType" : "gp2", "DeleteOnTermination": true } }
 				],
 				"UserData": {
-					"Fn::Base64": { 
+					"Fn::Base64": {
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r ComputeNode ", " --region ", {"Ref": "AWS::Region"}, "\n",

--- a/cfn/2-cluster.json
+++ b/cfn/2-cluster.json
@@ -10,19 +10,19 @@
 		"SnapshotID" : {
 			"Description"          : "Snapshot Id of the HPC Installation data",
 			"Type"                 : "String",
-			"AllowedPattern"       : "snap-([0-9a-fA-F]{8})",
+			"AllowedPattern"       : "((snap-([0-9a-fA-F]{8}))|(snap-([0-9a-fA-F]{17})))",
 			"ConstraintDescription": "must be a valid snapshot ID."
 		},
 		"ClusterSubnetID" : {
 			"Description"          : "Subnet Id of the HPC cluster",
 			"Type"                 : "String",
-			"AllowedPattern"       : "subnet-([0-9a-fA-F]{8})",
+			"AllowedPattern"       : "((subnet-([0-9a-fA-F]{8}))|(subnet-([0-9a-fA-F]{17})))",
 			"ConstraintDescription": "must be a valid subnet ID."
 		},
 		"ClusterSecurityGroupID" : {
 			"Description"          : "Security Group Id of the HPC cluster",
 			"Type"                 : "String",
-			"AllowedPattern"       : "sg-([0-9a-fA-F]{8})",
+			"AllowedPattern"       : "((sg-([0-9a-fA-F]{8}))|(sg-([0-9a-fA-F]{17})))",
 			"ConstraintDescription": "must be a valid security group ID."
 		},
 		"DomainDNSName" : {
@@ -58,8 +58,8 @@
 		"AWSAmiId" : {
 			"Description"          : "Identifier of the Amazon Machine Image to use for the platforms (all machines are started using the same AMI). We use Microsoft Windows Server 2012 R2 Base 64bits.",
 			"Type"                 : "String",
-			"AllowedPattern"       : "ami-([0-9a-fA-F]{8})",
-			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxx)."
+			"AllowedPattern"       : "ami-([0-9a-fA-F]{17})",
+			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxxxxxxxxxxx)."
 		},
 		"HeadNodeInstanceType" : {
 			"Description": "Instance type to use for the Head Node Instance",
@@ -117,8 +117,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [ 
-						{ 
+					"Statement": [
+						{
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -162,8 +162,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [ 
-						{ 
+					"Statement": [
+						{
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -311,7 +311,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": { 
+								"content": {
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf"
 									] ]
@@ -383,7 +383,7 @@
 					{ "DeviceName" : "xvdf", "Ebs" : { "SnapshotId": { "Ref": "SnapshotID" }, "VolumeSize": 100, "VolumeType" : "gp2", "DeleteOnTermination": true } }
 				],
 				"UserData": {
-					"Fn::Base64": { 
+					"Fn::Base64": {
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r HeadNode ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -469,7 +469,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": { 
+								"content": {
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf"
 									] ]
@@ -532,7 +532,7 @@
 					{ "DeviceName" : "xvdf", "Ebs" : { "SnapshotId": { "Ref": "SnapshotID" }, "VolumeSize": 100, "VolumeType" : "gp2", "DeleteOnTermination": true } }
 				],
 				"UserData": {
-					"Fn::Base64": { 
+					"Fn::Base64": {
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r ComputeNode ", " --region ", {"Ref": "AWS::Region"}, "\n",

--- a/cfn/2-cluster.json
+++ b/cfn/2-cluster.json
@@ -10,19 +10,19 @@
 		"SnapshotID" : {
 			"Description"          : "Snapshot Id of the HPC Installation data",
 			"Type"                 : "String",
-			"AllowedPattern"       : "((snap-([0-9a-fA-F]{8}))|(snap-([0-9a-fA-F]{17})))",
+			"AllowedPattern"       : "snap-([0-9a-fA-F]{8})",
 			"ConstraintDescription": "must be a valid snapshot ID."
 		},
 		"ClusterSubnetID" : {
 			"Description"          : "Subnet Id of the HPC cluster",
 			"Type"                 : "String",
-			"AllowedPattern"       : "((subnet-([0-9a-fA-F]{8}))|(subnet-([0-9a-fA-F]{17})))",
+			"AllowedPattern"       : "subnet-([0-9a-fA-F]{8})",
 			"ConstraintDescription": "must be a valid subnet ID."
 		},
 		"ClusterSecurityGroupID" : {
 			"Description"          : "Security Group Id of the HPC cluster",
 			"Type"                 : "String",
-			"AllowedPattern"       : "((sg-([0-9a-fA-F]{8}))|(sg-([0-9a-fA-F]{17})))",
+			"AllowedPattern"       : "sg-([0-9a-fA-F]{8})",
 			"ConstraintDescription": "must be a valid security group ID."
 		},
 		"DomainDNSName" : {
@@ -58,8 +58,8 @@
 		"AWSAmiId" : {
 			"Description"          : "Identifier of the Amazon Machine Image to use for the platforms (all machines are started using the same AMI). We use Microsoft Windows Server 2012 R2 Base 64bits.",
 			"Type"                 : "String",
-			"AllowedPattern"       : "ami-([0-9a-fA-F]{17})",
-			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxxxxxxxxxxx)."
+			"AllowedPattern"       : "ami-([0-9a-fA-F]{8})",
+			"ConstraintDescription": "must be a valid Amazon Machine Image (ami-xxxxxxxx)."
 		},
 		"HeadNodeInstanceType" : {
 			"Description": "Instance type to use for the Head Node Instance",
@@ -117,8 +117,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [
-						{
+					"Statement": [ 
+						{ 
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -162,8 +162,8 @@
 			"Properties": {
 				"AssumeRolePolicyDocument": {
 					"Version" : "2012-10-17",
-					"Statement": [
-						{
+					"Statement": [ 
+						{ 
 							"Effect": "Allow",
 							"Principal": { "Service": [ "ec2.amazonaws.com" ] },
 							"Action": [ "sts:AssumeRole" ]
@@ -311,7 +311,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": {
+								"content": { 
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf"
 									] ]
@@ -383,7 +383,7 @@
 					{ "DeviceName" : "xvdf", "Ebs" : { "SnapshotId": { "Ref": "SnapshotID" }, "VolumeSize": 100, "VolumeType" : "gp2", "DeleteOnTermination": true } }
 				],
 				"UserData": {
-					"Fn::Base64": {
+					"Fn::Base64": { 
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r HeadNode ", " --region ", {"Ref": "AWS::Region"}, "\n",
@@ -469,7 +469,7 @@
 								"authentication" : "rolebased"
 			                },
 							"C:\\cfn\\install\\CleanupFiles.cmd" : {
-								"content": {
+								"content": { 
 									"Fn::Join" : ["\n", [
 										"DEL c:\\cfn\\install\\hpc-user-info.conf"
 									] ]
@@ -532,7 +532,7 @@
 					{ "DeviceName" : "xvdf", "Ebs" : { "SnapshotId": { "Ref": "SnapshotID" }, "VolumeSize": 100, "VolumeType" : "gp2", "DeleteOnTermination": true } }
 				],
 				"UserData": {
-					"Fn::Base64": {
+					"Fn::Base64": { 
 						"Fn::Join": [ "", [
 							"<script>\n",
 							"cfn-init.exe -v -c config -s ", {"Ref": "AWS::StackId"}, " -r ComputeNode ", " --region ", {"Ref": "AWS::Region"}, "\n",


### PR DESCRIPTION
Current CF checks resource name validity to a short resource name only.
This change allows for a 17 characters resource name (introduced in 2017) while still allowing for 8 characters.
See https://aws.amazon.com/about-aws/whats-new/2018/02/longer-format-resource-ids-are-now-available-in-amazon-ec2/