### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/cfn/tool-find-image.json
+++ b/cfn/tool-find-image.json
@@ -59,7 +59,7 @@
 				"Handler" : "find-image.handler",
 				"MemorySize" : "128",
 				"Role" : { "Fn::GetAtt" : [ "FindImageRole", "Arn" ] },
-				"Runtime" : "nodejs4.3",
+				"Runtime" : "nodejs10.x",
 				"Timeout" : "25"
 			}
 		},

--- a/cfn/tool-find-snapshot.json
+++ b/cfn/tool-find-snapshot.json
@@ -59,7 +59,7 @@
 				"Handler" : "find-snapshot.handler",
 				"MemorySize" : "128",
 				"Role" : { "Fn::GetAtt" : [ "FindSnapshotRole", "Arn" ] },
-				"Runtime" : "nodejs4.3",
+				"Runtime" : "nodejs10.x",
 				"Timeout" : "25"
 			}
 		},


### PR DESCRIPTION
CloudFormation templates in aws-cfn-windows-hpc-template have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.